### PR TITLE
City of London is a City Corporation, not a County

### DIFF
--- a/data/local-authority-eng/local-authorities.tsv
+++ b/data/local-authority-eng/local-authorities.tsv
@@ -36,7 +36,7 @@ KWL	MD	Knowsley	Knowsley Metropolitan Borough Council	1974-04-01
 LCE	UA	Leicester	Leicester City Council	1905-06-19	
 LDS	MD	Leeds	Leeds City Council	1905-06-08	
 LIV	MD	Liverpool	Liverpool City Council	1905-06-08	
-LND	CTY	City of London	City of London Corporation	1905-06-28	
+LND	CC	City of London	City of London Corporation	1905-06-28	
 LUT	UA	Luton	Luton Borough Council	1905-06-19	
 MAN	MD	Manchester	Manchester City Council	1974-04-01	
 MDB	UA	Middlesbrough	Middlesbrough Borough Council	1905-06-18	

--- a/data/local-authority-type/local-authority-types.tsv
+++ b/data/local-authority-type/local-authority-types.tsv
@@ -1,5 +1,6 @@
 local-authority-type	name
 CA	Council area
+CC	City corporation
 CTY	County
 DIS	District
 LBO	London borough


### PR DESCRIPTION
Owen Boswava commented [via twitter](https://twitter.com/owenboswarva/status/792277606641074176) how the [City of London](https://local-authority-eng.register.gov.uk/record/LND) has been [recorded](https://local-authority-eng.register.gov.uk/item/sha-256:0bd11d488aadc456d4814853613a28dd26a1867702816376f4b5040968de3ad7) with a [local-authority-type](https://local-authority-type.register.gov.uk/records) of "County".

Our custodian has elected to record the City of London as having a new local-authority-type of "City Corporation".

This raises the priority of establishing the pattern for recording the reason why a record has changed, in this case correcting an error as opposed to the City of London actually changing its status, but that's a different story.