### PR TITLE
Correct start date of Birmingham City Council

### DIFF
--- a/data/local-authority-eng/local-authorities.tsv
+++ b/data/local-authority-eng/local-authorities.tsv
@@ -2,7 +2,7 @@ local-authority-eng	local-authority-type	name	official-name	start-date	end-date
 BAS	UA	Bath and North East Somerset	Bath and North East Somerset Council	1996-04-01	
 BBD	UA	Blackburn with Darwen	Blackburn with Darwen Borough Council	1998-04-01	
 BDF	UA	Bedford	Bedford Borough Council	2009-04-01	
-BIR	MD	Birmingham	Birmingham City Council	1996-07-01	
+BIR	MD	Birmingham	Birmingham City Council	1986-07-01	
 BMH	UA	Bournemouth	Bournemouth Borough Council	1905-06-19	
 BNH	UA	Brighton and Hove	Brighton and Hove City Council	1905-06-19	
 BNS	MD	Barnsley	Barnsley Metropolitan Borough Council	1974-04-01	


### PR DESCRIPTION
Birmingham District Council changed its name to Birmingham City Council
on 1st July 1986, not 1st July 1996. Birmingham District Council came
into existence in 1974.

Source: http://web.archive.org/web/20160319081846/http://www.birmingham.gov.uk/cs/Satellite?c=Page&childpagename=SystemAdmin%2FCFPageLayout&cid=1223092734590&packedargs=website%3D4&pagename=BCC%2FCommon%2FWrapper%2FCFWrapper&rendermode=live