### PR TITLE
Changed Kings Lynn to King's Lynn

### DIFF
--- a/data/local-authority-eng/local-authorities.tsv
+++ b/data/local-authority-eng/local-authorities.tsv
@@ -263,7 +263,7 @@ NFK	CTY	Norfolk	Norfolk County Council
 BRE	NMD	Breckland	Breckland District Council		
 BRO	NMD	Broadland	Broadland District Council		
 GRY	NMD	Great Yarmouth	Great Yarmouth Borough Council		
-KIN	NMD	Kings Lynn and West Norfolk	Borough Council of Kings Lynn and West Norfolk		
+KIN	NMD	King's Lynn and West Norfolk	Borough Council of King's Lynn and West Norfolk		
 NNO	NMD	North Norfolk	North Norfolk District Council		
 NOW	NMD	Norwich	Norwich City Council		
 SNO	NMD	South Norfolk	South Norfolk District Council		


### PR DESCRIPTION
Following feedback, and confirmation from the custodian, Kings Lynn is actually called King's Lynn