### PR TITLE
Rename registration-district-name to name in maps file

### DIFF
--- a/maps/registration-district.tsv
+++ b/maps/registration-district.tsv
@@ -1,4 +1,4 @@
-registration-district	local-authority	registration-district-name
+registration-district	local-authority	name
 218	local-authority-eng:BDG	Barking and Dagenham
 219	local-authority-eng:BNE	Barnet
 41	local-authority-eng:BNS	Barnsley


### PR DESCRIPTION
To comply with convention used by data list comparison app.