### PR TITLE
Change the 'name' of ELS

### DIFF
--- a/data/local-authority-sct/local-authority-sct.tsv
+++ b/data/local-authority-sct/local-authority-sct.tsv
@@ -10,7 +10,6 @@ EAY	CA	East Ayrshire	The East Ayrshire Council	1996-04-01
 EDH	CA	Edinburgh	The City of Edinburgh Council	1996-04-01	
 EDU	CA	East Dunbartonshire	The East Dunbartonshire Council	1996-04-01	
 ELN	CA	East Lothian	The East Lothian Council	1996-04-01	
-ELS	CA	Comhairle nan Eilean Siar	Comhairle nan Eilean Siar	1996-04-01	
 ERW	CA	East Renfrewshire	The East Renfrewshire Council	1996-04-01	
 FAL	CA	Falkirk	The Falkirk Council	1996-04-01	
 FIF	CA	Fife	The Fife Council	1996-04-01	
@@ -31,3 +30,4 @@ STG	CA	Stirling	The Stirling Council	1996-04-01
 WDU	CA	West Dunbartonshire	The West Dunbartonshire Council	1996-04-01	
 WLN	CA	West Lothian	The West Lothian Council	1996-04-01	
 ZET	CA	Shetland Islands	The Shetland Islands Council	1996-04-01	
+ELS	CA	Na h-Eileanan an Iar	Comhairle nan Eilean Siar	1996-04-01	


### PR DESCRIPTION
From the custodian:

> ... most of the complexity arises from Gaelic grammar which has the effect that the name of the statutory body (the council) and its area of responsibility are not immediately recognisable from each other. There is also added complexity in that Gaelic does not have language authorities which are as clearly established as those for English, and so there can be local debate around preferred Gaelic forms.
>
> In the register, “official-name” is used for the legally defined name and “name” for the commonly used name. Under section 23 of the Local Government (Scotland) Act 1973 the council agreed that from 1 January 1998 its area name should be “Na h-Eileanan an Iar” and its council name should be “Comhairle nan Eilean Siar”.
>
> The register currently has “Comhairle nan Eilean Siar” as both the official name and the common name. In order that both of the name forms are visible in the register, we have agreed here that it will be clearer for users if we amend the common name to “Na h-Eileanan an Iar” and keep the “official name” as “Comhairle nan Eilean Siar”.
>
> The form “Na h-Eileanan Siar” (which Kate refers to) is preferred by some council officials, but has no official status.